### PR TITLE
fix readme for docker on arm32v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,17 @@ To start the server, run `ruby app.rb` To view the interface, navigate to `local
 
 ## Docker
 
+### x86_64
+
 ```
     $> docker run -p4567:4567 dragonchaser/maptool:latest
 ```
+### arm32v7
+
+```
+    $> docker run -p4567:4567 dragonchaser/maptool:latest-arm32v7
+```
+
 
 ### Build
 


### PR DESCRIPTION
Update the Readme.md to contain info about prebuild arm32v7 images